### PR TITLE
bug/numeric-values-culture

### DIFF
--- a/src/Postgres.Marula.Calculations/Configuration/DefaultCalculationsConfiguration.cs
+++ b/src/Postgres.Marula.Calculations/Configuration/DefaultCalculationsConfiguration.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Microsoft.Extensions.Configuration;
 using Postgres.Marula.Infrastructure.Configuration;
 using Postgres.Marula.Infrastructure.Extensions;
@@ -20,7 +21,7 @@ namespace Postgres.Marula.Calculations.Configuration
 			=> ConfigurationSection
 				.GetSection("General:RecalculationIntervalInSeconds")
 				.Value
-				.To(double.Parse)
+				.To(stringValue => double.Parse(stringValue, CultureInfo.InvariantCulture))
 				.To(TimeSpan.FromSeconds);
 
 		/// <inheritdoc />
@@ -35,6 +36,6 @@ namespace Postgres.Marula.Calculations.Configuration
 			=> ConfigurationSection
 				.GetSection("Autovacuum:TargetRelationsBloatFraction")
 				.Value
-				.To(decimal.Parse);
+				.To(stringValue => decimal.Parse(stringValue, CultureInfo.InvariantCulture));
 	}
 }

--- a/src/Postgres.Marula.Calculations/ParameterValueParsing/DefaultParameterValueParser.cs
+++ b/src/Postgres.Marula.Calculations/ParameterValueParsing/DefaultParameterValueParser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Postgres.Marula.Calculations.Parameters.Base;
@@ -28,7 +29,7 @@ namespace Postgres.Marula.Calculations.ParameterValueParsing
 					=> ParseMemory(rawParameterValue.Value)
 						.To(memory => new MemoryParameterValue(parameterLink, memory)),
 
-				{ } when decimal.TryParse(rawParameterValue.Value, out var decimalValue)
+				{ } when decimal.TryParse(rawParameterValue.Value, NumberStyles.Number, CultureInfo.InvariantCulture, out var decimalValue)
 				         && rawParameterValue is RawRangeParameterValue rawRangeParameterValue
 					=> ToFraction(decimalValue, rawRangeParameterValue.ValidRange)
 						.To(fraction => new FractionParameterValue(parameterLink, fraction)),

--- a/src/Postgres.Marula.Calculations/ParameterValueParsing/DefaultParameterValueParser.cs
+++ b/src/Postgres.Marula.Calculations/ParameterValueParsing/DefaultParameterValueParser.cs
@@ -29,7 +29,11 @@ namespace Postgres.Marula.Calculations.ParameterValueParsing
 					=> ParseMemory(rawParameterValue.Value)
 						.To(memory => new MemoryParameterValue(parameterLink, memory)),
 
-				{ } when decimal.TryParse(rawParameterValue.Value, NumberStyles.Number, CultureInfo.InvariantCulture, out var decimalValue)
+				{ } when decimal.TryParse(
+					         rawParameterValue.Value,
+					         NumberStyles.Number,
+					         CultureInfo.InvariantCulture,
+					         out var decimalValue)
 				         && rawParameterValue is RawRangeParameterValue rawRangeParameterValue
 					=> ToFraction(decimalValue, rawRangeParameterValue.ValidRange)
 						.To(fraction => new FractionParameterValue(parameterLink, fraction)),

--- a/src/Postgres.Marula.Calculations/Parameters/Base/IParameterLink.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/Base/IParameterLink.cs
@@ -14,5 +14,5 @@ namespace Postgres.Marula.Calculations.Parameters.Base
 	}
 
 	/// <inheritdoc cref="IParameterLink"/>
-	public sealed record ParameterLink(NonEmptyString Name) : IParameterLink;
+	internal sealed record ParameterLink(NonEmptyString Name) : IParameterLink;
 }

--- a/src/Postgres.Marula.DatabaseAccess/ConnectionFactory/DefaultPreparedDbConnectionFactory.cs
+++ b/src/Postgres.Marula.DatabaseAccess/ConnectionFactory/DefaultPreparedDbConnectionFactory.cs
@@ -32,9 +32,10 @@ namespace Postgres.Marula.DatabaseAccess.ConnectionFactory
 		/// </summary>
 		private async Task<IDbConnection> PrepareConnectionAsync(IDbConnection dbConnection)
 		{
-			if (dbConnection.State != ConnectionState.Open)
+			if (!dbConnection.State.HasFlag(ConnectionState.Open))
 			{
-				await ((DbConnection) dbConnection).OpenAsync();
+				if (dbConnection is DbConnection awaitableConnection) await awaitableConnection.OpenAsync();
+				else dbConnection.Open();
 			}
 
 			await sqlScriptsExecutor.ExecuteScriptsAsync(dbConnection);

--- a/src/Postgres.Marula.DatabaseAccess/ServerInteraction/DefaultDatabaseServer.cs
+++ b/src/Postgres.Marula.DatabaseAccess/ServerInteraction/DefaultDatabaseServer.cs
@@ -105,6 +105,9 @@ namespace Postgres.Marula.DatabaseAccess.ServerInteraction
 				: new RawParameterValue(parameterValue);
 		}
 
+		/// <summary>
+		/// Cache of parameter context values.
+		/// </summary>
 		private static readonly ConcurrentDictionary<NonEmptyString, ParameterContext> contextCache = new();
 
 		/// <inheritdoc />

--- a/src/Postgres.Marula.Infrastructure/Extensions/PropertyInfoExtensions.cs
+++ b/src/Postgres.Marula.Infrastructure/Extensions/PropertyInfoExtensions.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+
+namespace Postgres.Marula.Infrastructure.Extensions
+{
+	/// <summary>
+	/// Extension methods for <see cref="PropertyInfo"/> type.
+	/// </summary>
+	public static class PropertyInfoExtensions
+	{
+		/// <summary>
+		/// Get value of type <typeparamref name="TValue"/> from property <paramref name="propertyInfo"/>
+		/// of object <paramref name="propertyOwner"/>.
+		/// </summary>
+		public static TValue GetValue<TValue>(
+			this PropertyInfo propertyInfo,
+			object propertyOwner) => (TValue) propertyInfo.GetValue(propertyOwner)!;
+	}
+}

--- a/src/Postgres.Marula.Infrastructure/TypeDecorators/NonEmptyString.cs
+++ b/src/Postgres.Marula.Infrastructure/TypeDecorators/NonEmptyString.cs
@@ -9,10 +9,16 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 	{
 		private readonly string underlyingValue;
 
-		private NonEmptyString(string stringValue)
-			=> this.underlyingValue = string.IsNullOrWhiteSpace(stringValue)
-				? throw new ArgumentException("String value can't be whitespace.", nameof(stringValue))
-				: stringValue;
+		private NonEmptyString(string underlyingValue)
+			=> this.underlyingValue = string.IsNullOrWhiteSpace(underlyingValue)
+				? throw new ArgumentException("String value can't be whitespace.", nameof(underlyingValue))
+				: underlyingValue;
+
+		/// <summary>
+		/// Replace substring <paramref name="substring"/> with value <paramref name="replaceWith"/>
+		/// and return new <see cref="NonEmptyString"/> instance. 
+		/// </summary>
+		public NonEmptyString Replace(NonEmptyString substring, string replaceWith) => underlyingValue.Replace(substring, replaceWith);
 
 		/// <inheritdoc />
 		public override string ToString() => underlyingValue;


### PR DESCRIPTION
- invariant culture in numeric values parsing
- aggregation instead of `StringBuilder` in **scripts provider**
- db connection type check instead of explicit cast in **connection factory**