### PR TITLE
fix/async-lazy

### DIFF
--- a/src/Postgres.Marula.AppHost/HostedService.cs
+++ b/src/Postgres.Marula.AppHost/HostedService.cs
@@ -26,7 +26,7 @@ namespace Postgres.Marula.AppHost
 		/// <inheritdoc />
 		protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 		{
-			jobs.ForEach(job => job.Run());
+			jobs.ForEach(job => job.Start());
 			logger.LogInformation("Marula application is running.");
 			await Task.CompletedTask;
 		}

--- a/src/Postgres.Marula.Calculations/Jobs/Base/IJob.cs
+++ b/src/Postgres.Marula.Calculations/Jobs/Base/IJob.cs
@@ -6,9 +6,9 @@ namespace Postgres.Marula.Calculations.Jobs.Base
 	public interface IJob
 	{
 		/// <summary>
-		/// Run job.
+		/// Start job.
 		/// </summary>
-		void Run();
+		void Start();
 
 		/// <summary>
 		/// Stop job.

--- a/src/Postgres.Marula.Calculations/Jobs/Base/JobBase.cs
+++ b/src/Postgres.Marula.Calculations/Jobs/Base/JobBase.cs
@@ -73,7 +73,7 @@ namespace Postgres.Marula.Calculations.Jobs.Base
 				.Then(intervalTimer => intervalTimer.Elapsed += async (_, _) => await OnTimerElapsed());
 
 		/// <inheritdoc />
-		void IJob.Run() => timer.Start();
+		void IJob.Start() => timer.Start();
 
 		/// <inheritdoc />
 		void IJob.Stop() => timer.Stop();

--- a/src/Postgres.Marula.Calculations/Parameters/Base/ParameterBase.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/Base/ParameterBase.cs
@@ -30,7 +30,7 @@ namespace Postgres.Marula.Calculations.Parameters.Base
 		public virtual IParameterDependencies Dependencies() => ParameterDependencies.Empty;
 
 		/// <inheritdoc />
-		Task<IParameterValue> IParameter.CalculateAsync() => valueAsyncCache.Value;
+		async Task<IParameterValue> IParameter.CalculateAsync() => await valueAsyncCache;
 
 		/// <inheritdoc cref="IParameter.CalculateAsync"/>
 		/// <remarks>

--- a/src/Postgres.Marula.DatabaseAccess/ConnectionFactory/DefaultDbConnectionFactory.cs
+++ b/src/Postgres.Marula.DatabaseAccess/ConnectionFactory/DefaultDbConnectionFactory.cs
@@ -34,7 +34,7 @@ namespace Postgres.Marula.DatabaseAccess.ConnectionFactory
 		}
 
 		/// <inheritdoc />
-		Task<IDbConnection> IDbConnectionFactory.GetConnectionAsync() => lazyPreparedConnection.Value;
+		async Task<IDbConnection> IDbConnectionFactory.GetConnectionAsync() => await lazyPreparedConnection;
 
 		/// <summary>
 		/// Prepare database connection for future communications with server.

--- a/src/Postgres.Marula.HwInfo/HardwareInfoBase.cs
+++ b/src/Postgres.Marula.HwInfo/HardwareInfoBase.cs
@@ -26,10 +26,10 @@ namespace Postgres.Marula.HwInfo
 		}
 
 		/// <inheritdoc />
-		Task<Memory> IHardwareInfo.TotalRam() => ramSizeAsyncCache.Value;
+		async Task<Memory> IHardwareInfo.TotalRam() => await ramSizeAsyncCache;
 
 		/// <inheritdoc />
-		Task<CoresCount> IHardwareInfo.CpuCoresCount() => coresCountAsyncCache.Value;
+		async Task<CoresCount> IHardwareInfo.CpuCoresCount() => await coresCountAsyncCache;
 
 		/// <summary>
 		/// Path to executable.

--- a/src/Postgres.Marula.Infrastructure/TypeDecorators/AsyncLazy.cs
+++ b/src/Postgres.Marula.Infrastructure/TypeDecorators/AsyncLazy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,14 +8,52 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 	/// <summary>
 	/// Provides lazy asynchronous initialization. 
 	/// </summary>
-	public class AsyncLazy<T> : Lazy<Task<T>>
+	/// <remarks>
+	/// Underlying <see cref="Lazy{T}"/> object
+	/// configured with <see cref="LazyThreadSafetyMode.PublicationOnly"/> mode.
+	/// </remarks>
+	public class AsyncLazy<T>
 	{
+		private readonly object lockObject;
+		private readonly Func<Task<T>> factoryWithRetry;
+		private Lazy<Task<T>> instance;
+
 		/// <inheritdoc cref="Lazy{T}(Func{T}, LazyThreadSafetyMode)"/>
-		public AsyncLazy(
-			Func<Task<T>> factory,
-			LazyThreadSafetyMode threadSafetyMode = LazyThreadSafetyMode.PublicationOnly)
-			: base(factory, threadSafetyMode)
+		public AsyncLazy(Func<Task<T>> factory)
 		{
+			lockObject = new();
+			factoryWithRetry = RetryOnFailure(factory);
+			instance = New();
 		}
+
+		/// <summary>
+		/// Get awaiter object. 
+		/// </summary>
+		public TaskAwaiter<T> GetAwaiter()
+		{
+			lock (lockObject) return instance.Value.GetAwaiter();
+		}
+
+		/// <summary>
+		/// Create delegate which wraps <paramref name="factory"/> with try-catch-reset block. 
+		/// </summary>
+		private Func<Task<T>> RetryOnFailure(Func<Task<T>> factory)
+			=> async () =>
+			{
+				try
+				{
+					return await factory();
+				}
+				catch
+				{
+					lock (lockObject) instance = New();
+					throw;
+				}
+			};
+
+		/// <summary>
+		/// Create new <see cref="Lazy{T}"/> object. 
+		/// </summary>
+		private Lazy<Task<T>> New() => new(factoryWithRetry, LazyThreadSafetyMode.PublicationOnly);
 	}
 }

--- a/src/Postgres.Marula.Infrastructure/TypeDecorators/AsyncLazy.cs
+++ b/src/Postgres.Marula.Infrastructure/TypeDecorators/AsyncLazy.cs
@@ -18,7 +18,9 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 		private readonly Func<Task<T>> factoryWithRetry;
 		private Lazy<Task<T>> instance;
 
-		/// <inheritdoc cref="Lazy{T}(Func{T}, LazyThreadSafetyMode)"/>
+		/// <summary>
+		/// Create new instance of <see cref="AsyncLazy{T}"/> which uses <paramref name="factory"/>. 
+		/// </summary>
 		public AsyncLazy(Func<Task<T>> factory)
 		{
 			lockObject = new();

--- a/src/Postgres.Marula.Tests/Calculations/JobTests.cs
+++ b/src/Postgres.Marula.Tests/Calculations/JobTests.cs
@@ -23,7 +23,7 @@ namespace Postgres.Marula.Tests.Calculations
 		{
 			var allJobs = GetService<IEnumerable<IJob>>().ToImmutableArray();
 
-			allJobs.ForEach(job => job.Run());
+			allJobs.ForEach(job => job.Start());
 
 			await Task.Delay(TimeSpan.FromSeconds(5));
 

--- a/src/Postgres.Marula.Tests/SetUpFixture.cs
+++ b/src/Postgres.Marula.Tests/SetUpFixture.cs
@@ -53,7 +53,7 @@ namespace Postgres.Marula.Tests
 					FileName = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, AgentExecutableName()),
 					RedirectStandardError = true,
 					UseShellExecute = false,
-					CreateNoWindow = true,
+					CreateNoWindow = true
 				}
 			};
 


### PR DESCRIPTION
Re-implementation of `AsyncLazy<T>` type:
* Retry on failure - exceptions occured inside of async factory method are not cached
* GetAwaiter - async lazy can be awaited directly