### PR TITLE
test launch bugs

### DIFF
--- a/docs/autovacuum-tuning-design.md
+++ b/docs/autovacuum-tuning-design.md
@@ -71,7 +71,7 @@ Specifies the minimum number of updated or deleted tuples needed to trigger a va
 
 Value calculated based on **table size EV** and can be represented by formula:
 ```
-autovacuum_vacuum_threshold = 0.01 * {table_size_expected_value}
+autovacuum_vacuum_threshold = max(50, 0.01 * {table_size_expected_value})
 ```
 
 ### autovacuum_vacuum_cost_delay

--- a/src/Postgres.Marula.Calculations/Exceptions/Error.cs
+++ b/src/Postgres.Marula.Calculations/Exceptions/Error.cs
@@ -9,18 +9,18 @@ namespace Postgres.Marula.Calculations.Exceptions
 	{
 		/// <summary>
 		/// Get exception object which is thrown when
-		/// there are not enough LSN history entries
+		/// there is not enough LSN history entries
 		/// in window <see cref="IPeriodicLoggingConfiguration.MovingAverageWindow"/>.
 		/// </summary>
 		public static ParameterValueCalculationException NoLsnHistory()
-			=> new("There are not enough LSN history entries in configured window.");
+			=> new("There is not enough LSN history entries in configured window.");
 
 		/// <summary>
 		/// Get exception object which is thrown when
-		/// there not enough bloat fraction history entries
+		/// there is not enough bloat fraction history entries
 		/// in window <see cref="IPeriodicLoggingConfiguration.MovingAverageWindow"/>.
 		/// </summary>
 		public static ParameterValueCalculationException NoBloatHistory()
-			=> new("There are not enough bloat fraction history entries in configured window.");
+			=> new("There is not enough bloat fraction history entries in configured window.");
 	}
 }

--- a/src/Postgres.Marula.Calculations/Exceptions/Error.cs
+++ b/src/Postgres.Marula.Calculations/Exceptions/Error.cs
@@ -9,10 +9,18 @@ namespace Postgres.Marula.Calculations.Exceptions
 	{
 		/// <summary>
 		/// Get exception object which is thrown when
-		/// there are no any LSN history entries
+		/// there are not enough LSN history entries
 		/// in window <see cref="IPeriodicLoggingConfiguration.MovingAverageWindow"/>.
 		/// </summary>
 		public static ParameterValueCalculationException NoLsnHistory()
-			=> new("There are no any LSN history entries in configured window.");
+			=> new("There are not enough LSN history entries in configured window.");
+
+		/// <summary>
+		/// Get exception object which is thrown when
+		/// there not enough bloat fraction history entries
+		/// in window <see cref="IPeriodicLoggingConfiguration.MovingAverageWindow"/>.
+		/// </summary>
+		public static ParameterValueCalculationException NoBloatHistory()
+			=> new("There are not enough bloat fraction history entries in configured window.");
 	}
 }

--- a/src/Postgres.Marula.Calculations/Exceptions/Error.cs
+++ b/src/Postgres.Marula.Calculations/Exceptions/Error.cs
@@ -1,3 +1,4 @@
+using System;
 using Postgres.Marula.Calculations.Configuration;
 
 namespace Postgres.Marula.Calculations.Exceptions
@@ -8,7 +9,7 @@ namespace Postgres.Marula.Calculations.Exceptions
 	internal static class Error
 	{
 		/// <summary>
-		/// Get exception object which is thrown when
+		/// Get exception object which is being thrown when
 		/// there is not enough LSN history entries
 		/// in window <see cref="IPeriodicLoggingConfiguration.MovingAverageWindow"/>.
 		/// </summary>
@@ -16,11 +17,18 @@ namespace Postgres.Marula.Calculations.Exceptions
 			=> new("There is not enough LSN history entries in configured window.");
 
 		/// <summary>
-		/// Get exception object which is thrown when
+		/// Get exception object which is being thrown when
 		/// there is not enough bloat fraction history entries
 		/// in window <see cref="IPeriodicLoggingConfiguration.MovingAverageWindow"/>.
 		/// </summary>
 		public static ParameterValueCalculationException NoBloatHistory()
 			=> new("There is not enough bloat fraction history entries in configured window.");
+
+		/// <summary>
+		/// Get exception object which is being thrown when
+		/// remote agent access operation failed.
+		/// </summary>
+		public static RemoteAgentAccessException FailedToAccessAgent(Exception exception)
+			=> new("Failed to access remote agent.", exception);
 	}
 }

--- a/src/Postgres.Marula.Calculations/Exceptions/RemoteAgentAccessException.cs
+++ b/src/Postgres.Marula.Calculations/Exceptions/RemoteAgentAccessException.cs
@@ -4,24 +4,24 @@ using System.Runtime.Serialization;
 namespace Postgres.Marula.Calculations.Exceptions
 {
 	/// <summary>
-	/// Error related to parameters calculations.
+	/// Exception being raised on remote access failure.
 	/// </summary>
 	[Serializable]
-	internal class ParameterValueCalculationException : ApplicationException
+	public class RemoteAgentAccessException : ApplicationException
 	{
 		/// <summary>
 		/// Initializes a new instance of the <see cref="RemoteAgentAccessException"/> class
 		/// with a specified error message.
 		/// </summary>
-		public ParameterValueCalculationException(string message) : base(message)
+		public RemoteAgentAccessException(string message, Exception exception) : base(message, exception)
 		{
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="ParameterValueCalculationException"/> class
+		/// Initializes a new instance of the <see cref="RemoteAgentAccessException"/> class
 		/// with serialized data.
 		/// </summary>
-		protected ParameterValueCalculationException(
+		protected RemoteAgentAccessException(
 			SerializationInfo info,
 			StreamingContext context) : base(info, context)
 		{

--- a/src/Postgres.Marula.Calculations/HardwareInfo/RemoteHardwareInfo.cs
+++ b/src/Postgres.Marula.Calculations/HardwareInfo/RemoteHardwareInfo.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Postgres.Marula.Calculations.Configuration;
 using Postgres.Marula.HwInfo;
@@ -40,7 +42,42 @@ namespace Postgres.Marula.Calculations.HardwareInfo
 		{
 			var httpResponseMessage = await httpClient.SendAsync(new(httpMethod, route));
 			var responseBody = await httpResponseMessage.Content.ReadAsStringAsync();
-			return JsonSerializer.Deserialize<TResponse>(responseBody)!;
+			var options = new JsonSerializerOptions { Converters = { MemoryConverter.Instance } };
+			return JsonSerializer.Deserialize<TResponse>(responseBody, options)!;
+		}
+
+		/// <summary>
+		/// JSON read-only converter for <see cref="Memory"/> type.
+		/// </summary>
+		private sealed class MemoryConverter : JsonConverter<Memory>
+		{
+			private MemoryConverter()
+			{
+			}
+
+			/// <summary>
+			/// Converter instance.
+			/// </summary>
+			public static MemoryConverter Instance { get; } = new();
+
+			/// <inheritdoc />
+			public override Memory Read(
+				ref Utf8JsonReader reader,
+				Type typeToConvert,
+				JsonSerializerOptions options)
+			{
+				reader.Read(); // skip start object: '{'
+				reader.Read(); // skip property name: 'totalBytes'
+				var totalBytesValue = reader.GetUInt64();
+				while (reader.TokenType != JsonTokenType.EndObject) reader.Read();
+				return new(totalBytesValue);
+			}
+
+			/// <inheritdoc />
+			public override void Write(
+				Utf8JsonWriter writer,
+				Memory value,
+				JsonSerializerOptions options) => throw new NotSupportedException();
 		}
 	}
 }

--- a/src/Postgres.Marula.Calculations/Jobs/Base/JobBase.cs
+++ b/src/Postgres.Marula.Calculations/Jobs/Base/JobBase.cs
@@ -49,11 +49,11 @@ namespace Postgres.Marula.Calculations.Jobs.Base
 			try
 			{
 				await ExecuteAsync(serviceScope);
-				logger.LogInformation($"[{Description}] iteration completed successfully.");
+				logger.LogInformation($"[{Description}] iteration is completed.");
 			}
 			catch (Exception exception)
 			{
-				logger.LogError(exception, $"[{Description}] error occured during iteration.");
+				logger.LogError(exception, $"[{Description}] iteration is failed.");
 			}
 			finally
 			{

--- a/src/Postgres.Marula.Calculations/ParameterValues/Base/IParameterValue.cs
+++ b/src/Postgres.Marula.Calculations/ParameterValues/Base/IParameterValue.cs
@@ -1,7 +1,5 @@
-using System;
 using Postgres.Marula.Calculations.ParameterProperties;
 using Postgres.Marula.Calculations.Parameters.Base;
-using Postgres.Marula.Infrastructure.TypeDecorators;
 
 namespace Postgres.Marula.Calculations.ParameterValues.Base
 {
@@ -19,31 +17,5 @@ namespace Postgres.Marula.Calculations.ParameterValues.Base
 		/// Parameter unit.
 		/// </summary>
 		IUnit Unit { get; }
-	}
-
-	/// <summary>
-	/// Represents absence of value.
-	/// </summary>
-	public sealed class NullValue : IParameterValue
-	{
-		private NullValue(NonEmptyString parameterName)
-			=> ParameterLink = new ParameterLink(parameterName);
-
-		/// <summary>
-		/// Create new instance of <see cref="NullValue"/> related to <paramref name="parameter"/>. 
-		/// </summary>
-		public static IParameterValue OfParameter(IParameter parameter)
-			=> new NullValue(parameter.Name);
-
-		/// <inheritdoc />
-		public IParameterLink ParameterLink { get; }
-
-		/// <inheritdoc />
-		IUnit IParameterValue.Unit => throw AccessError();
-
-		/// <summary>
-		/// Get exception object to throw on any member access. 
-		/// </summary>
-		private static InvalidOperationException AccessError() => throw new($"Unable to access {nameof(NullValue)} members.");
 	}
 }

--- a/src/Postgres.Marula.Calculations/ParameterValues/Base/IParameterValue.cs
+++ b/src/Postgres.Marula.Calculations/ParameterValues/Base/IParameterValue.cs
@@ -1,6 +1,7 @@
 using System;
 using Postgres.Marula.Calculations.ParameterProperties;
 using Postgres.Marula.Calculations.Parameters.Base;
+using Postgres.Marula.Infrastructure.TypeDecorators;
 
 namespace Postgres.Marula.Calculations.ParameterValues.Base
 {
@@ -25,15 +26,17 @@ namespace Postgres.Marula.Calculations.ParameterValues.Base
 	/// </summary>
 	public sealed class NullValue : IParameterValue
 	{
-		private NullValue()
-		{
-		}
+		private NullValue(NonEmptyString parameterName)
+			=> ParameterLink = new ParameterLink(parameterName);
 
-		/// <inheritdoc cref="NullValue"/>
-		public static IParameterValue Instance { get; } = new NullValue();
+		/// <summary>
+		/// Create new instance of <see cref="NullValue"/> related to <paramref name="parameter"/>. 
+		/// </summary>
+		public static IParameterValue OfParameter(IParameter parameter)
+			=> new NullValue(parameter.Name);
 
 		/// <inheritdoc />
-		IParameterLink IParameterValue.ParameterLink => throw AccessError();
+		public IParameterLink ParameterLink { get; }
 
 		/// <inheritdoc />
 		IUnit IParameterValue.Unit => throw AccessError();

--- a/src/Postgres.Marula.Calculations/ParameterValues/Base/IParameterValue.cs
+++ b/src/Postgres.Marula.Calculations/ParameterValues/Base/IParameterValue.cs
@@ -11,7 +11,7 @@ namespace Postgres.Marula.Calculations.ParameterValues.Base
 		/// <summary>
 		/// Link to parameter.
 		/// </summary>
-		IParameterLink ParameterLink { get; }
+		IParameterLink Link { get; }
 
 		/// <summary>
 		/// Parameter unit.

--- a/src/Postgres.Marula.Calculations/ParameterValues/Base/ParameterValueBase.cs
+++ b/src/Postgres.Marula.Calculations/ParameterValues/Base/ParameterValueBase.cs
@@ -10,7 +10,7 @@ namespace Postgres.Marula.Calculations.ParameterValues.Base
 	{
 		private protected ParameterValueBase(IParameterLink parameterLink, T value)
 		{
-			ParameterLink = parameterLink;
+			Link = parameterLink;
 			Value = value;
 		}
 
@@ -20,7 +20,7 @@ namespace Postgres.Marula.Calculations.ParameterValues.Base
 		public T Value { get; }
 
 		/// <inheritdoc />
-		public IParameterLink ParameterLink { get; }
+		public IParameterLink Link { get; }
 
 		/// <inheritdoc />
 		public abstract IUnit Unit { get; }
@@ -35,7 +35,7 @@ namespace Postgres.Marula.Calculations.ParameterValues.Base
 		{
 			if (ReferenceEquals(null, other)) return false;
 			if (ReferenceEquals(this, other)) return true;
-			return Value.Equals(other.Value) && ParameterLink.Equals(other.ParameterLink) && Unit.Equals(other.Unit);
+			return Value.Equals(other.Value) && Link.Equals(other.Link) && Unit.Equals(other.Unit);
 		}
 
 		/// <inheritdoc />
@@ -48,7 +48,7 @@ namespace Postgres.Marula.Calculations.ParameterValues.Base
 		}
 
 		/// <inheritdoc />
-		public override int GetHashCode() => HashCode.Combine(Value, ParameterLink, Unit);
+		public override int GetHashCode() => HashCode.Combine(Value, Link, Unit);
 
 		#endregion
 	}

--- a/src/Postgres.Marula.Calculations/ParameterValues/Base/ParameterValueWithStatus.cs
+++ b/src/Postgres.Marula.Calculations/ParameterValues/Base/ParameterValueWithStatus.cs
@@ -1,4 +1,5 @@
 using Postgres.Marula.Calculations.ParameterProperties;
+using Postgres.Marula.Calculations.ParameterProperties.StringRepresentation;
 
 namespace Postgres.Marula.Calculations.ParameterValues.Base
 {
@@ -22,5 +23,9 @@ namespace Postgres.Marula.Calculations.ParameterValues.Base
 		/// Parameter calculation status.
 		/// </summary>
 		public CalculationStatus CalculationStatus { get; }
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> $"{Value.ParameterLink.Name}: {Value} ({CalculationStatus.StringRepresentation()})";
 	}
 }

--- a/src/Postgres.Marula.Calculations/ParameterValues/Base/ParameterValueWithStatus.cs
+++ b/src/Postgres.Marula.Calculations/ParameterValues/Base/ParameterValueWithStatus.cs
@@ -26,6 +26,6 @@ namespace Postgres.Marula.Calculations.ParameterValues.Base
 
 		/// <inheritdoc />
 		public override string ToString()
-			=> $"{Value.ParameterLink.Name}: {Value} ({CalculationStatus.StringRepresentation()})";
+			=> $"{Value.Link.Name}: {Value} ({CalculationStatus.StringRepresentation()})";
 	}
 }

--- a/src/Postgres.Marula.Calculations/ParameterValues/NullValue.cs
+++ b/src/Postgres.Marula.Calculations/ParameterValues/NullValue.cs
@@ -12,7 +12,7 @@ namespace Postgres.Marula.Calculations.ParameterValues
 	public sealed class NullValue : IParameterValue
 	{
 		private NullValue(NonEmptyString parameterName)
-			=> ParameterLink = new ParameterLink(parameterName);
+			=> Link = new ParameterLink(parameterName);
 
 		/// <summary>
 		/// Create new instance of <see cref="NullValue"/> related to <paramref name="parameter"/>. 
@@ -21,7 +21,7 @@ namespace Postgres.Marula.Calculations.ParameterValues
 			=> new NullValue(parameter.Name);
 
 		/// <inheritdoc />
-		public IParameterLink ParameterLink { get; }
+		public IParameterLink Link { get; }
 
 		/// <inheritdoc />
 		IUnit IParameterValue.Unit => throw AccessError();

--- a/src/Postgres.Marula.Calculations/ParameterValues/NullValue.cs
+++ b/src/Postgres.Marula.Calculations/ParameterValues/NullValue.cs
@@ -2,7 +2,6 @@ using System;
 using Postgres.Marula.Calculations.ParameterProperties;
 using Postgres.Marula.Calculations.Parameters.Base;
 using Postgres.Marula.Calculations.ParameterValues.Base;
-using Postgres.Marula.Infrastructure.TypeDecorators;
 
 namespace Postgres.Marula.Calculations.ParameterValues
 {
@@ -11,14 +10,13 @@ namespace Postgres.Marula.Calculations.ParameterValues
 	/// </summary>
 	public sealed class NullValue : IParameterValue
 	{
-		private NullValue(NonEmptyString parameterName)
-			=> Link = new ParameterLink(parameterName);
+		private NullValue(IParameterLink link) => Link = link;
 
 		/// <summary>
 		/// Create new instance of <see cref="NullValue"/> related to <paramref name="parameter"/>. 
 		/// </summary>
 		public static IParameterValue OfParameter(IParameter parameter)
-			=> new NullValue(parameter.Name);
+			=> new NullValue(parameter.GetLink());
 
 		/// <inheritdoc />
 		public IParameterLink Link { get; }

--- a/src/Postgres.Marula.Calculations/ParameterValues/NullValue.cs
+++ b/src/Postgres.Marula.Calculations/ParameterValues/NullValue.cs
@@ -1,0 +1,34 @@
+using System;
+using Postgres.Marula.Calculations.ParameterProperties;
+using Postgres.Marula.Calculations.Parameters.Base;
+using Postgres.Marula.Calculations.ParameterValues.Base;
+using Postgres.Marula.Infrastructure.TypeDecorators;
+
+namespace Postgres.Marula.Calculations.ParameterValues
+{
+	/// <summary>
+	/// Represents absence of value.
+	/// </summary>
+	public sealed class NullValue : IParameterValue
+	{
+		private NullValue(NonEmptyString parameterName)
+			=> ParameterLink = new ParameterLink(parameterName);
+
+		/// <summary>
+		/// Create new instance of <see cref="NullValue"/> related to <paramref name="parameter"/>. 
+		/// </summary>
+		public static IParameterValue OfParameter(IParameter parameter)
+			=> new NullValue(parameter.Name);
+
+		/// <inheritdoc />
+		public IParameterLink ParameterLink { get; }
+
+		/// <inheritdoc />
+		IUnit IParameterValue.Unit => throw AccessError();
+
+		/// <summary>
+		/// Get exception object to throw on any member access. 
+		/// </summary>
+		private static InvalidOperationException AccessError() => throw new($"Unable to access {nameof(NullValue)} members.");
+	}
+}

--- a/src/Postgres.Marula.Calculations/Parameters/Autovacuum/AutovacuumVacuumThreshold.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/Autovacuum/AutovacuumVacuumThreshold.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Postgres.Marula.Calculations.ExternalDependencies;
@@ -26,12 +27,12 @@ namespace Postgres.Marula.Calculations.Parameters.Autovacuum
 		/// <inheritdoc />
 		/// <remarks>
 		/// Value calculated based on table size EV and can be represented by formula:
-		/// autovacuum_vacuum_threshold = 0.01 * {table_size_expected_value}
+		/// autovacuum_vacuum_threshold = max(50, 0.01 * {table_size_expected_value})
 		/// </remarks>
 		protected override async ValueTask<TuplesCount> CalculateValueAsync()
 		{
 			var averageTableSize = await databaseServer.GetAverageTableSizeAsync();
-			return (TuplesCount) 0.01 * averageTableSize;
+			return Math.Max(50, (TuplesCount) 0.01 * averageTableSize);
 		}
 	}
 }

--- a/src/Postgres.Marula.Calculations/Parameters/Base/ParameterBase.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/Base/ParameterBase.cs
@@ -44,10 +44,13 @@ namespace Postgres.Marula.Calculations.Parameters.Base
 			{
 				value = await CalculateValueAsync();
 			}
-			catch (ParameterValueCalculationException exception)
+			catch (Exception exception)
+				when (exception
+					is ParameterValueCalculationException
+					or RemoteAgentAccessException)
 			{
 				logger.LogError(exception, $"Failed to calculate value of parameter '{Name}'.");
-				return NullValue.Instance;
+				return NullValue.OfParameter(this);
 			}
 
 			return Activator

--- a/src/Postgres.Marula.Calculations/Parameters/Base/ParameterBase.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/Base/ParameterBase.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Postgres.Marula.Calculations.Exceptions;
 using Postgres.Marula.Calculations.Parameters.Base.Dependencies;
+using Postgres.Marula.Calculations.ParameterValues;
 using Postgres.Marula.Calculations.ParameterValues.Base;
 using Postgres.Marula.Infrastructure.Extensions;
 using Postgres.Marula.Infrastructure.TypeDecorators;

--- a/src/Postgres.Marula.Calculations/Parameters/Wal/MaxWalSize.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/Wal/MaxWalSize.cs
@@ -67,11 +67,9 @@ namespace Postgres.Marula.Calculations.Parameters.Wal
 			var multiplier = await databaseServer.GetPostgresVersionAsync() >= new Version(11, 0) ? 1 : 2;
 			var checkpointCompletionTarget = await pgSettings.ReadAsync<CheckpointCompletionTarget, Fraction>();
 
-			var maxWalSizeInBytes = walTrafficPerSecond
-									* checkpointTimeout.TotalSeconds
-									* (multiplier + checkpointCompletionTarget);
-
-			return new((ulong) maxWalSizeInBytes);
+			return walTrafficPerSecond
+			       * checkpointTimeout.TotalSeconds
+			       * (multiplier + checkpointCompletionTarget);
 		}
 
 		/// <summary>

--- a/src/Postgres.Marula.Calculations/ParametersManagement/PgSettings.cs
+++ b/src/Postgres.Marula.Calculations/ParametersManagement/PgSettings.cs
@@ -40,7 +40,7 @@ namespace Postgres.Marula.Calculations.ParametersManagement
 		void IPgSettings.Apply(IParameterValue parameterValue)
 		{
 			if (parameterValue is NullValue) return;
-			valuesCache[parameterValue.ParameterLink] = new(parameterValue, Updated: true);
+			valuesCache[parameterValue.Link] = new(parameterValue, Updated: true);
 		}
 
 		/// <inheritdoc />
@@ -57,7 +57,7 @@ namespace Postgres.Marula.Calculations.ParametersManagement
 		private async ValueTask<CalculationStatus> GetCalculationStatus(IParameterValue parameterValue)
 		{
 			var adjustmentIsAllowed = configuration.General().AutoAdjustmentIsEnabled();
-			var parameterContext = await databaseServer.GetParameterContextAsync(parameterValue.ParameterLink);
+			var parameterContext = await databaseServer.GetParameterContextAsync(parameterValue.Link);
 
 			return (adjustmentIsAllowed, parameterContext.RestartIsRequired()) switch
 			{

--- a/src/Postgres.Marula.Calculations/ParametersManagement/PgSettings.cs
+++ b/src/Postgres.Marula.Calculations/ParametersManagement/PgSettings.cs
@@ -8,6 +8,7 @@ using Postgres.Marula.Calculations.Configuration;
 using Postgres.Marula.Calculations.ExternalDependencies;
 using Postgres.Marula.Calculations.ParameterProperties;
 using Postgres.Marula.Calculations.Parameters.Base;
+using Postgres.Marula.Calculations.ParameterValues;
 using Postgres.Marula.Calculations.ParameterValues.Base;
 using Postgres.Marula.Calculations.ParameterValues.Parsing;
 using Postgres.Marula.Infrastructure.Extensions;

--- a/src/Postgres.Marula.Calculations/Pipeline/Factory/DefaultPipelineFactory.cs
+++ b/src/Postgres.Marula.Calculations/Pipeline/Factory/DefaultPipelineFactory.cs
@@ -15,8 +15,8 @@ namespace Postgres.Marula.Calculations.Pipeline.Factory
 				.To(scope => new ServiceScopeMiddlewareResolver(scope))
 				.To(resolver => new AsyncPipeline<ParametersManagementContext>(resolver))
 				.Add<ValueCalculationsMiddleware>()
-				.Add<ParametersAdjustmentMiddleware>()
-				.Add<ValuesHistoryMiddleware>();
+				.Add<ValuesHistoryMiddleware>()
+				.Add<ParametersAdjustmentMiddleware>();
 
 			var pipelineContext = pipelineScope.ServiceProvider.GetRequiredService<ParametersManagementContext>();
 

--- a/src/Postgres.Marula.Calculations/Pipeline/MiddlewareComponents/ValueCalculationsMiddleware.cs
+++ b/src/Postgres.Marula.Calculations/Pipeline/MiddlewareComponents/ValueCalculationsMiddleware.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using PipelineNet.Middleware;
 using Postgres.Marula.Calculations.Parameters.Base;
 using Postgres.Marula.Calculations.ParametersManagement;
+using Postgres.Marula.Calculations.ParameterValues;
 using Postgres.Marula.Calculations.ParameterValues.Base;
 using Postgres.Marula.Infrastructure.Extensions;
 

--- a/src/Postgres.Marula.Calculations/Pipeline/MiddlewareComponents/ValueCalculationsMiddleware.cs
+++ b/src/Postgres.Marula.Calculations/Pipeline/MiddlewareComponents/ValueCalculationsMiddleware.cs
@@ -64,7 +64,7 @@ namespace Postgres.Marula.Calculations.Pipeline.MiddlewareComponents
 				return await parameterToCalculate.CalculateAsync();
 			}
 
-			var parameterNames = notCalculated.Select(value => value.ParameterLink.Name);
+			var parameterNames = notCalculated.Select(value => value.Link.Name);
 			logger.LogWarning(
 				$"Unable to calculate value of parameter '{parameterToCalculate.Name}' " +
 				$"because it has dependencies which are not calculated: [{parameterNames.JoinBy(", ")}].");

--- a/src/Postgres.Marula.Calculations/Pipeline/MiddlewareComponents/ValueCalculationsMiddleware.cs
+++ b/src/Postgres.Marula.Calculations/Pipeline/MiddlewareComponents/ValueCalculationsMiddleware.cs
@@ -67,7 +67,7 @@ namespace Postgres.Marula.Calculations.Pipeline.MiddlewareComponents
 			logger.LogWarning(
 				$"Unable to calculate value of parameter '{parameterToCalculate.Name}' " +
 				$"because it has dependencies which are not calculated: [{parameterNames.JoinBy(", ")}].");
-			return NullValue.Instance;
+			return NullValue.OfParameter(parameterToCalculate);
 		}
 
 		/// <summary>

--- a/src/Postgres.Marula.DatabaseAccess/ConnectionFactory/DefaultDbConnectionFactory.cs
+++ b/src/Postgres.Marula.DatabaseAccess/ConnectionFactory/DefaultDbConnectionFactory.cs
@@ -45,7 +45,7 @@ namespace Postgres.Marula.DatabaseAccess.ConnectionFactory
 			}
 
 			// Acquire lock to prevent multiple threads from parallel scripts execution.
-			using var _ = new Lock(lockTimeout: TimeSpan.FromMinutes(1));
+			using var _ = await Lock.AcquireAsync(lockTimeout: TimeSpan.FromMinutes(1));
 
 			if (!await DatabaseStructureIsPrepared(dbConnection))
 			{

--- a/src/Postgres.Marula.DatabaseAccess/ConnectionFactory/DefaultDbConnectionFactory.cs
+++ b/src/Postgres.Marula.DatabaseAccess/ConnectionFactory/DefaultDbConnectionFactory.cs
@@ -17,7 +17,6 @@ namespace Postgres.Marula.DatabaseAccess.ConnectionFactory
 	internal class DefaultDbConnectionFactory : IDbConnectionFactory
 	{
 		private readonly AsyncLazy<IDbConnection> lazyPreparedConnection;
-
 		private readonly ISqlScriptsExecutor sqlScriptsExecutor;
 		private readonly INamingConventions namingConventions;
 
@@ -44,6 +43,9 @@ namespace Postgres.Marula.DatabaseAccess.ConnectionFactory
 				if (dbConnection is DbConnection awaitableConnection) await awaitableConnection.OpenAsync();
 				else dbConnection.Open();
 			}
+
+			// Acquire lock to prevent multiple threads from parallel scripts execution.
+			using var _ = new Lock(lockTimeout: TimeSpan.FromMinutes(1));
 
 			if (!await DatabaseStructureIsPrepared(dbConnection))
 			{

--- a/src/Postgres.Marula.DatabaseAccess/ServerInteraction/DefaultDatabaseServer.cs
+++ b/src/Postgres.Marula.DatabaseAccess/ServerInteraction/DefaultDatabaseServer.cs
@@ -45,7 +45,7 @@ namespace Postgres.Marula.DatabaseAccess.ServerInteraction
 
 			var alterSystemCommands = await parameterValues
 				.SelectAsync(async value =>
-					$"alter system set {value.ParameterLink.Name} = " +
+					$"alter system set {value.Link.Name} = " +
 					$"'{await GetValueStringRepresentation(value)}';");
 
 			var commandText = alterSystemCommands
@@ -79,7 +79,7 @@ namespace Postgres.Marula.DatabaseAccess.ServerInteraction
 			var connection = await Connection();
 			var (minValue, maxValue) = await connection.QuerySingleAsync<(decimal, decimal)>(
 				commandText,
-				new {parameterValue.ParameterLink.Name});
+				new {parameterValue.Link.Name});
 
 			var multiplier = (minValue, maxValue) switch
 			{
@@ -87,7 +87,7 @@ namespace Postgres.Marula.DatabaseAccess.ServerInteraction
 				(decimal.Zero, 100)         => 100,
 				_ => throw new NotSupportedException(
 					$"Fraction parameter range [{minValue} .. {maxValue}] is not " +
-					$"supported (parameter '{parameterValue.ParameterLink.Name}').")
+					$"supported (parameter '{parameterValue.Link.Name}').")
 			};
 
 			return (fractionParameterValue.Value * multiplier).ToString(CultureInfo.InvariantCulture);

--- a/src/Postgres.Marula.DatabaseAccess/ServerInteraction/DefaultSystemStorage.cs
+++ b/src/Postgres.Marula.DatabaseAccess/ServerInteraction/DefaultSystemStorage.cs
@@ -73,7 +73,7 @@ namespace Postgres.Marula.DatabaseAccess.ServerInteraction
 		private NonEmptyString ToValuesString(ParameterValueWithStatus parameterValue)
 			=> new []
 				{
-					$"'{parameterValue.Value.ParameterLink.Name}'",
+					$"'{parameterValue.Value.Link.Name}'",
 
 					$"'{parameterValue.Value}'",
 

--- a/src/Postgres.Marula.DatabaseAccess/SqlScripts/Executor/DefaultSqlScriptsExecutor.cs
+++ b/src/Postgres.Marula.DatabaseAccess/SqlScripts/Executor/DefaultSqlScriptsExecutor.cs
@@ -24,6 +24,7 @@ namespace Postgres.Marula.DatabaseAccess.SqlScripts.Executor
 		/// <inheritdoc />
 		async Task ISqlScriptsExecutor.ExecuteScriptsAsync(IDbConnection dbConnection)
 		{
+			logger.LogInformation("Scripts execution is started.");
 			using var dbTransaction = dbConnection.BeginTransaction();
 
 			foreach (var sqlScript in sqlScriptsProvider.GetAllOrderedByExecution())
@@ -40,6 +41,7 @@ namespace Postgres.Marula.DatabaseAccess.SqlScripts.Executor
 			}
 
 			dbTransaction.Commit();
+			logger.LogInformation("Scripts execution completed successfully.");
 		}
 	}
 }

--- a/src/Postgres.Marula.HwInfo/PowershellHardwareInfo.cs
+++ b/src/Postgres.Marula.HwInfo/PowershellHardwareInfo.cs
@@ -26,7 +26,7 @@ namespace Postgres.Marula.HwInfo
 		{
 			const string command = "(Get-CimInstance Win32_PhysicalMemory | Measure-Object -Property capacity -Sum).Sum";
 			var totalRamInBytesString = await ExecuteCommandAsync(command);
-			return ulong.Parse(totalRamInBytesString);
+			return new(ulong.Parse(totalRamInBytesString));
 		}
 
 		/// <inheritdoc />

--- a/src/Postgres.Marula.Infrastructure/TypeDecorators/Lock.cs
+++ b/src/Postgres.Marula.Infrastructure/TypeDecorators/Lock.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Postgres.Marula.Infrastructure.TypeDecorators
 {
@@ -8,15 +9,23 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 	/// </summary>
 	public sealed class Lock : IDisposable
 	{
-		private readonly object lockObject = new();
+		private static readonly SemaphoreSlim semaphore = new(initialCount: 1, maxCount: 1);
 
-		public Lock(PositiveTimeSpan lockTimeout)
+		private Lock()
 		{
-			if (!Monitor.TryEnter(lockObject, lockTimeout))
-				throw new TimeoutException($"Lock acquiring timeout exceeded ({lockTimeout}).");
+		}
+
+		/// <summary>
+		/// Asynchronously acquire disposable lock. 
+		/// </summary>
+		public static async Task<Lock> AcquireAsync(PositiveTimeSpan lockTimeout)
+		{
+			var timeoutExceeded = !await semaphore.WaitAsync(lockTimeout);
+			if (timeoutExceeded) throw new TimeoutException($"Lock acquiring timeout exceeded ({lockTimeout}).");
+			return new Lock();
 		}
 
 		/// <inheritdoc />
-		void IDisposable.Dispose() => Monitor.Exit(lockObject);
+		void IDisposable.Dispose() => semaphore.Release();
 	}
 }

--- a/src/Postgres.Marula.Infrastructure/TypeDecorators/Lock.cs
+++ b/src/Postgres.Marula.Infrastructure/TypeDecorators/Lock.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading;
+
+namespace Postgres.Marula.Infrastructure.TypeDecorators
+{
+	/// <summary>
+	/// Disposable exclusive lock.
+	/// </summary>
+	public sealed class Lock : IDisposable
+	{
+		private readonly object lockObject = new();
+
+		public Lock(PositiveTimeSpan lockTimeout)
+		{
+			if (!Monitor.TryEnter(lockObject, lockTimeout))
+				throw new TimeoutException($"Lock acquiring timeout exceeded ({lockTimeout}).");
+		}
+
+		/// <inheritdoc />
+		void IDisposable.Dispose() => Monitor.Exit(lockObject);
+	}
+}

--- a/src/Postgres.Marula.Infrastructure/TypeDecorators/Memory.cs
+++ b/src/Postgres.Marula.Infrastructure/TypeDecorators/Memory.cs
@@ -73,6 +73,11 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 		#region Constants
 
 		/// <summary>
+		/// Zero memory size - 0B.
+		/// </summary>
+		public static Memory Zero => new(0);
+
+		/// <summary>
 		/// One byte - 1B.
 		/// </summary>
 		public static Memory Byte => new(1);

--- a/src/Postgres.Marula.Infrastructure/TypeDecorators/Memory.cs
+++ b/src/Postgres.Marula.Infrastructure/TypeDecorators/Memory.cs
@@ -23,10 +23,10 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 			=> TotalBytes switch
 			{
 				< 10UL * 1024                      => (TotalBytes, Unit.Bytes),
-				< 10UL * 1024 * 1024               => (TotalBytes / Kilobyte, Unit.Kilobytes),
-				< 10UL * 1024 * 1024 * 1024        => (TotalBytes / Megabyte, Unit.Megabytes),
-				< 10UL * 1024 * 1024 * 1024 * 1024 => (TotalBytes / Gigabyte, Unit.Gigabytes),
-				_                                  => (TotalBytes / Terabyte, Unit.Terabytes)
+				< 10UL * 1024 * 1024               => (TotalBytes / Kilobyte.TotalBytes, Unit.Kilobytes),
+				< 10UL * 1024 * 1024 * 1024        => (TotalBytes / Megabyte.TotalBytes, Unit.Megabytes),
+				< 10UL * 1024 * 1024 * 1024 * 1024 => (TotalBytes / Gigabyte.TotalBytes, Unit.Gigabytes),
+				_                                  => (TotalBytes / Terabyte.TotalBytes, Unit.Terabytes)
 			};
 
 		/// <inheritdoc />
@@ -80,22 +80,22 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 		/// <summary>
 		/// One kilobyte - 1024B.
 		/// </summary>
-		public static Memory Kilobyte => new(1024);
+		public static Memory Kilobyte => 1024 * Byte;
 
 		/// <summary>
 		/// One megabyte - 1024kB.
 		/// </summary>
-		public static Memory Megabyte => new(1024D * Kilobyte);
+		public static Memory Megabyte => 1024 * Kilobyte;
 
 		/// <summary>
 		/// One gigabyte - 1024MB.
 		/// </summary>
-		public static Memory Gigabyte => new(1024D * Megabyte);
+		public static Memory Gigabyte => 1024 * Megabyte;
 
 		/// <summary>
 		/// One terabyte - 1024GB.
 		/// </summary>
-		public static Memory Terabyte => new(1024D * Gigabyte);
+		public static Memory Terabyte => 1024 * Gigabyte;
 
 		#endregion
 
@@ -127,32 +127,43 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 				_    => throw InvalidFormat()
 			};
 
-			return new Memory(numericValue * (ulong) multiplier);
+			return numericValue * multiplier;
 		}
+
+		#region Operators
 
 		/// <summary>
 		/// Multiplication operator.
 		/// </summary>
+		public static Memory operator *(Memory memory, ulong coefficient) => new(memory.TotalBytes * coefficient);
+
+		/// <inheritdoc cref="op_Multiply(Memory,ulong)"/>
+		public static Memory operator *(ulong coefficient, Memory memory) => memory * coefficient;
+
+		/// <inheritdoc cref="op_Multiply(Memory,ulong)"/>
 		public static Memory operator *(Memory memory, double coefficient) => new(memory.TotalBytes *  (ulong) coefficient);
 
-
-		/// <inheritdoc cref="op_Multiply(Memory,double)"/>
+		/// <inheritdoc cref="op_Multiply(Memory,ulong)"/>
 		public static Memory operator *(double coefficient, Memory memory) => memory * coefficient;
+
+		/// <inheritdoc cref="op_Multiply(Memory,ulong)"/>
+		public static Memory operator *(Memory memory, decimal coefficient) => new(memory.TotalBytes *  (ulong) coefficient);
+
+		/// <inheritdoc cref="op_Multiply(Memory,ulong)"/>
+		public static Memory operator *(decimal coefficient, Memory memory) => memory * coefficient;
 
 		/// <summary>
 		/// Division operator.
 		/// </summary>
+		public static Memory operator /(Memory memory, ulong coefficient) => new(memory.TotalBytes / coefficient);
+
+		/// <inheritdoc cref="op_Division(Memory,ulong)"/>
 		public static Memory operator /(Memory memory, double coefficient) => new(memory.TotalBytes /  (ulong) coefficient);
 
-		/// <summary>
-		/// Implicit cast operator <see cref="ulong"/> -> <see cref="Memory"/>.
-		/// </summary>
-		public static implicit operator Memory(ulong bytes) => new(bytes);
+		/// <inheritdoc cref="op_Division(Memory,ulong)"/>
+		public static Memory operator /(Memory memory, decimal coefficient) => new(memory.TotalBytes /  (ulong) coefficient);
 
-		/// <summary>
-		/// Implicit cast operator <see cref="Memory"/> -> <see cref="ulong"/>.
-		/// </summary>
-		public static implicit operator ulong(Memory memory) => memory.TotalBytes;
+		#endregion
 
 		/// <summary>
 		/// Memory unit.

--- a/src/Postgres.Marula.Infrastructure/TypeDecorators/Memory.cs
+++ b/src/Postgres.Marula.Infrastructure/TypeDecorators/Memory.cs
@@ -146,13 +146,13 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 		public static Memory operator *(ulong coefficient, Memory memory) => memory * coefficient;
 
 		/// <inheritdoc cref="op_Multiply(Memory,ulong)"/>
-		public static Memory operator *(Memory memory, double coefficient) => new(memory.TotalBytes *  (ulong) coefficient);
+		public static Memory operator *(Memory memory, double coefficient) => new((ulong) (memory.TotalBytes * coefficient));
 
 		/// <inheritdoc cref="op_Multiply(Memory,ulong)"/>
 		public static Memory operator *(double coefficient, Memory memory) => memory * coefficient;
 
 		/// <inheritdoc cref="op_Multiply(Memory,ulong)"/>
-		public static Memory operator *(Memory memory, decimal coefficient) => new(memory.TotalBytes *  (ulong) coefficient);
+		public static Memory operator *(Memory memory, decimal coefficient) => new((ulong) (memory.TotalBytes * coefficient));
 
 		/// <inheritdoc cref="op_Multiply(Memory,ulong)"/>
 		public static Memory operator *(decimal coefficient, Memory memory) => memory * coefficient;
@@ -163,10 +163,10 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 		public static Memory operator /(Memory memory, ulong coefficient) => new(memory.TotalBytes / coefficient);
 
 		/// <inheritdoc cref="op_Division(Memory,ulong)"/>
-		public static Memory operator /(Memory memory, double coefficient) => new(memory.TotalBytes /  (ulong) coefficient);
+		public static Memory operator /(Memory memory, double coefficient) => new((ulong) (memory.TotalBytes / coefficient));
 
 		/// <inheritdoc cref="op_Division(Memory,ulong)"/>
-		public static Memory operator /(Memory memory, decimal coefficient) => new(memory.TotalBytes /  (ulong) coefficient);
+		public static Memory operator /(Memory memory, decimal coefficient) => new((ulong) (memory.TotalBytes / coefficient));
 
 		#endregion
 

--- a/src/Postgres.Marula.Tests/Calculations/Base/CalculationsTestFixtureBase.cs
+++ b/src/Postgres.Marula.Tests/Calculations/Base/CalculationsTestFixtureBase.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Postgres.Marula.Calculations;
 using Postgres.Marula.Calculations.ExternalDependencies;
+using Postgres.Marula.HwInfo;
 using Postgres.Marula.Tests.Base;
 using Postgres.Marula.Tests.Calculations.FakeServices;
 
@@ -20,7 +21,8 @@ namespace Postgres.Marula.Tests.Calculations.Base
 				.AddSingleton<FakeDatabaseServer>()
 				.AddSingleton<IDatabaseServer>(provider => provider.GetRequiredService<FakeDatabaseServer>())
 				.AddSingleton<IDatabaseServerAccessTracker>(provider => provider.GetRequiredService<FakeDatabaseServer>())
-				.AddSingleton<ISystemStorage, FakeSystemStorage>();
+				.AddSingleton<ISystemStorage, FakeSystemStorage>()
+				.AddSingleton<IHardwareInfo, FakeHardwareInfo>();
 		}
 	}
 }

--- a/src/Postgres.Marula.Tests/Calculations/FakeServices/FakeHardwareInfo.cs
+++ b/src/Postgres.Marula.Tests/Calculations/FakeServices/FakeHardwareInfo.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using Postgres.Marula.HwInfo;
+using Postgres.Marula.Infrastructure.TypeDecorators;
+
+// ReSharper disable BuiltInTypeReferenceStyle
+using CoresCount = System.Byte;
+
+namespace Postgres.Marula.Tests.Calculations.FakeServices
+{
+	/// <inheritdoc />
+	internal class FakeHardwareInfo : IHardwareInfo
+	{
+		/// <inheritdoc />
+		Task<Memory> IHardwareInfo.TotalRam() => Task.FromResult(16 * Memory.Gigabyte);
+
+		/// <inheritdoc />
+		Task<CoresCount> IHardwareInfo.CpuCoresCount() => Task.FromResult((CoresCount) 8);
+	}
+}

--- a/src/Postgres.Marula.Tests/Calculations/ParameterValueParserTests.cs
+++ b/src/Postgres.Marula.Tests/Calculations/ParameterValueParserTests.cs
@@ -28,7 +28,7 @@ namespace Postgres.Marula.Tests.Calculations
 
 			Assert.IsInstanceOf<TimeSpanParameterValue>(parameterValue);
 			Assert.AreEqual(new IUnit.Milliseconds(), parameterValue.Unit);
-			Assert.AreEqual(parameterLink, parameterValue.ParameterLink);
+			Assert.AreEqual(parameterLink, parameterValue.Link);
 		}
 
 		/// <summary>
@@ -46,7 +46,7 @@ namespace Postgres.Marula.Tests.Calculations
 			Assert.IsInstanceOf<MemoryParameterValue>(parameterValue);
 			// 4GB is less then 10GB, so it's normalized to megabytes.
 			Assert.AreEqual(new IUnit.Mem(Memory.Unit.Megabytes), parameterValue.Unit);
-			Assert.AreEqual(parameterLink, parameterValue.ParameterLink);
+			Assert.AreEqual(parameterLink, parameterValue.Link);
 		}
 
 		/// <summary>
@@ -63,7 +63,7 @@ namespace Postgres.Marula.Tests.Calculations
 
 			Assert.IsInstanceOf<FractionParameterValue>(parameterValue);
 			Assert.AreEqual(new IUnit.None(), parameterValue.Unit);
-			Assert.AreEqual(parameterLink, parameterValue.ParameterLink);
+			Assert.AreEqual(parameterLink, parameterValue.Link);
 		}
 
 		/// <summary>
@@ -80,7 +80,7 @@ namespace Postgres.Marula.Tests.Calculations
 
 			Assert.IsInstanceOf<FractionParameterValue>(parameterValue);
 			Assert.AreEqual(new IUnit.None(), parameterValue.Unit);
-			Assert.AreEqual(parameterLink, parameterValue.ParameterLink);
+			Assert.AreEqual(parameterLink, parameterValue.Link);
 		}
 
 		/// <summary>
@@ -97,7 +97,7 @@ namespace Postgres.Marula.Tests.Calculations
 
 			Assert.IsInstanceOf<BooleanParameterValue>(parameterValue);
 			Assert.AreEqual(new IUnit.None(), parameterValue.Unit);
-			Assert.AreEqual(parameterLink, parameterValue.ParameterLink);
+			Assert.AreEqual(parameterLink, parameterValue.Link);
 			Assert.AreEqual(underlyingValue, ((BooleanParameterValue) parameterValue).Value);
 		}
 
@@ -116,7 +116,7 @@ namespace Postgres.Marula.Tests.Calculations
 
 			Assert.IsInstanceOf<IntegerParameterValue>(parameterValue);
 			Assert.AreEqual(new IUnit.None(), parameterValue.Unit);
-			Assert.AreEqual(parameterLink, parameterValue.ParameterLink);
+			Assert.AreEqual(parameterLink, parameterValue.Link);
 			Assert.AreEqual(underlyingValue, ((IntegerParameterValue) parameterValue).Value);
 		}
 	}

--- a/src/Postgres.Marula.Tests/DatabaseAccess/DatabaseServerTests.cs
+++ b/src/Postgres.Marula.Tests/DatabaseAccess/DatabaseServerTests.cs
@@ -76,10 +76,10 @@ namespace Postgres.Marula.Tests.DatabaseAccess
 			// let postmaster reload configuration. 
 			await Task.Delay(millisecondsDelay: 100);
 
-			var rawParameterValue = await databaseServer.GetRawParameterValueAsync(valueToApply.ParameterLink);
+			var rawParameterValue = await databaseServer.GetRawParameterValueAsync(valueToApply.Link);
 
 			var parameterValueParser = GetService<IParameterValueParser>();
-			var parsedValue = parameterValueParser.Parse(valueToApply.ParameterLink, rawParameterValue);
+			var parsedValue = parameterValueParser.Parse(valueToApply.Link, rawParameterValue);
 			Assert.AreEqual(valueToApply, parsedValue);
 		}
 
@@ -141,7 +141,7 @@ namespace Postgres.Marula.Tests.DatabaseAccess
 			var parameterValueParser = GetService<IParameterValueParser>();
 
 			var valuesFromServer = await parameterValues
-				.Select(parameterValue => parameterValue.ParameterLink)
+				.Select(parameterValue => parameterValue.Link)
 				.SelectAsync(async parameterLink =>
 				{
 					var rawParameterValue = await databaseServer.GetRawParameterValueAsync(parameterLink);

--- a/src/Postgres.Marula.Tests/HwInfo/HardwareInfoTestBase.cs
+++ b/src/Postgres.Marula.Tests/HwInfo/HardwareInfoTestBase.cs
@@ -7,15 +7,14 @@ using Postgres.Marula.Tests.Base;
 namespace Postgres.Marula.Tests.HwInfo
 {
 	/// <summary>
-	/// Hardware agent tests
+	/// Base class for <see cref="IHardwareInfo"/> implementations.
 	/// </summary>
-	internal class HardwareInfoTests : SingleComponentTestFixtureBase<HwInfoAppComponent>
+	internal abstract class HardwareInfoTestBase : SingleComponentTestFixtureBase<HwInfoAppComponent>
 	{
 		/// <summary>
 		/// Get total RAM size.
 		/// </summary>
-		[Test]
-		public async Task GetTotalMemoryTest()
+		protected async Task GetTotalMemoryTestImpl()
 		{
 			var hardwareInfo = GetService<IHardwareInfo>();
 			var totalMemory = await hardwareInfo.TotalRam();
@@ -25,8 +24,7 @@ namespace Postgres.Marula.Tests.HwInfo
 		/// <summary>
 		/// Get CPU cores count.
 		/// </summary>
-		[Test]
-		public async Task GetCpuCoresCountTest()
+		protected async Task GetCpuCoresCountTestImpl()
 		{
 			var hardwareInfo = GetService<IHardwareInfo>();
 			var coresCount = await hardwareInfo.CpuCoresCount();

--- a/src/Postgres.Marula.Tests/HwInfo/HardwareInfoTests.cs
+++ b/src/Postgres.Marula.Tests/HwInfo/HardwareInfoTests.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Postgres.Marula.HwInfo;
+using Postgres.Marula.Infrastructure.TypeDecorators;
 using Postgres.Marula.Tests.Base;
 
 namespace Postgres.Marula.Tests.HwInfo
@@ -18,7 +19,7 @@ namespace Postgres.Marula.Tests.HwInfo
 		{
 			var hardwareInfo = GetService<IHardwareInfo>();
 			var totalMemory = await hardwareInfo.TotalRam();
-			Assert.AreNotEqual(0, totalMemory.TotalBytes);
+			Assert.AreNotEqual(Memory.Zero, totalMemory);
 		}
 
 		/// <summary>

--- a/src/Postgres.Marula.Tests/HwInfo/LocalHardwareInfoTests.cs
+++ b/src/Postgres.Marula.Tests/HwInfo/LocalHardwareInfoTests.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Postgres.Marula.HwInfo;
+
+namespace Postgres.Marula.Tests.HwInfo
+{
+	/// <summary>
+	/// Tests of <see cref="IHardwareInfo"/> running locally.
+	/// </summary>
+	internal class LocalHardwareInfoTests : HardwareInfoTestBase
+	{
+		/// <inheritdoc cref="HardwareInfoTestBase.GetTotalMemoryTestImpl"/>
+		[Test]
+		public async Task GetLocalTotalMemoryTest() => await GetTotalMemoryTestImpl();
+
+		/// <inheritdoc cref="HardwareInfoTestBase.GetCpuCoresCountTestImpl"/>
+		[Test]
+		public async Task GetLocalCpuCoresCountTest() => await GetCpuCoresCountTestImpl();
+	}
+}

--- a/src/Postgres.Marula.Tests/HwInfo/RemoteHardwareInfoTests.cs
+++ b/src/Postgres.Marula.Tests/HwInfo/RemoteHardwareInfoTests.cs
@@ -2,22 +2,29 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Postgres.Marula.Agent;
+using Postgres.Marula.Calculations.HardwareInfo;
+using Postgres.Marula.HwInfo;
 using Postgres.Marula.Infrastructure.Extensions;
 using Postgres.Marula.Infrastructure.TypeDecorators;
 
-// ReSharper disable SwitchExpressionHandlesSomeKnownEnumValuesWithExceptionInDefault
-
-namespace Postgres.Marula.Tests
+namespace Postgres.Marula.Tests.HwInfo
 {
 	/// <summary>
-	/// Tests initialisation.
+	/// <see cref="RemoteHardwareInfo"/> tests.
 	/// </summary>
-	[SetUpFixture]
-	internal class SetUpFixture
+	internal class RemoteHardwareInfoTests : HardwareInfoTests
 	{
 		private readonly Process agentApiProcess = CreateAgentProcess();
+
+		/// <inheritdoc/>
+		protected override void ConfigureServices(IServiceCollection serviceCollection)
+		{
+			base.ConfigureServices(serviceCollection);
+			serviceCollection.AddSingleton<IHardwareInfo, RemoteHardwareInfo>();
+		}
 
 		/// <summary>
 		/// Start agent process.
@@ -37,16 +44,19 @@ namespace Postgres.Marula.Tests
 				});
 		}
 
+		/// <inheritdoc cref="HardwareInfoTests.GetTotalMemoryTest"/>
+		[Test]
+		public new async Task GetTotalMemoryTest() => await base.GetTotalMemoryTest();
+
+		/// <inheritdoc cref="HardwareInfoTests.GetCpuCoresCountTest"/>
+		[Test]
+		public new async Task GetCpuCoresCountTest() => await base.GetCpuCoresCountTest();
+
 		/// <summary>
 		/// Kill agent process.
 		/// </summary>
 		[OneTimeTearDown]
-		public async Task OneTimeTearDown()
-		{
-			// let already running jobs to finish
-			await Task.Delay(millisecondsDelay: 5000);
-			agentApiProcess.Kill();
-		}
+		public void OneTimeTearDown() => agentApiProcess.Kill();
 
 		/// <summary>
 		/// Create agent web api process. 

--- a/src/Postgres.Marula.Tests/HwInfo/RemoteHardwareInfoTests.cs
+++ b/src/Postgres.Marula.Tests/HwInfo/RemoteHardwareInfoTests.cs
@@ -13,11 +13,11 @@ using Postgres.Marula.Infrastructure.TypeDecorators;
 namespace Postgres.Marula.Tests.HwInfo
 {
 	/// <summary>
-	/// <see cref="RemoteHardwareInfo"/> tests.
+	/// Tests of <see cref="RemoteHardwareInfo"/> which performs HTTP requests to remote agent's API.
 	/// </summary>
-	internal class RemoteHardwareInfoTests : HardwareInfoTests
+	internal class RemoteHardwareInfoTests : HardwareInfoTestBase
 	{
-		private readonly Process agentApiProcess = CreateAgentProcess();
+		private readonly Process remoteAgentApiProcess = CreateAgentProcess();
 
 		/// <inheritdoc/>
 		protected override void ConfigureServices(IServiceCollection serviceCollection)
@@ -32,9 +32,9 @@ namespace Postgres.Marula.Tests.HwInfo
 		[OneTimeSetUp]
 		public void OneTimeSetUp()
 		{
-			agentApiProcess.Start();
+			remoteAgentApiProcess.Start();
 
-			agentApiProcess
+			remoteAgentApiProcess
 				.StandardError
 				.ReadToEndAsync()
 				.ContinueWith(task =>
@@ -44,19 +44,19 @@ namespace Postgres.Marula.Tests.HwInfo
 				});
 		}
 
-		/// <inheritdoc cref="HardwareInfoTests.GetTotalMemoryTest"/>
+		/// <inheritdoc cref="HardwareInfoTestBase.GetTotalMemoryTestImpl"/>
 		[Test]
-		public new async Task GetTotalMemoryTest() => await base.GetTotalMemoryTest();
+		public async Task GetRemoteTotalMemoryTest() => await GetTotalMemoryTestImpl();
 
-		/// <inheritdoc cref="HardwareInfoTests.GetCpuCoresCountTest"/>
+		/// <inheritdoc cref="HardwareInfoTestBase.GetCpuCoresCountTestImpl"/>
 		[Test]
-		public new async Task GetCpuCoresCountTest() => await base.GetCpuCoresCountTest();
+		public async Task GetRemoteCpuCoresCountTest() => await GetCpuCoresCountTestImpl();
 
 		/// <summary>
 		/// Kill agent process.
 		/// </summary>
 		[OneTimeTearDown]
-		public void OneTimeTearDown() => agentApiProcess.Kill();
+		public void OneTimeTearDown() => remoteAgentApiProcess.Kill();
 
 		/// <summary>
 		/// Create agent web api process. 

--- a/src/Postgres.Marula.Tests/Infrastructure/ConnectionStringTests.cs
+++ b/src/Postgres.Marula.Tests/Infrastructure/ConnectionStringTests.cs
@@ -9,7 +9,7 @@ namespace Postgres.Marula.Tests.Infrastructure
 	/// Database connection string tests.
 	/// </summary>
 	[TestFixture]
-	public class ConnectionStringTests
+	internal class ConnectionStringTests
 	{
 		[Test]
 		public void SingleKeyValueTest()

--- a/src/Postgres.Marula.Tests/Infrastructure/MemoryTests.cs
+++ b/src/Postgres.Marula.Tests/Infrastructure/MemoryTests.cs
@@ -61,7 +61,7 @@ namespace Postgres.Marula.Tests.Infrastructure
 		private static IEnumerable<OperatorTestCase> OperatorTestCases()
 			=> new OperatorTestCase[]
 			{
-				new(() => 0.25 * Memory.Gigabyte, 256 * Memory.Megabyte)
+				new(() => 0.25 * Memory.Gigabyte, Memory.Parse("256MB"))
 			};
 
 		/// <summary>

--- a/src/Postgres.Marula.Tests/Infrastructure/MemoryTests.cs
+++ b/src/Postgres.Marula.Tests/Infrastructure/MemoryTests.cs
@@ -29,12 +29,12 @@ namespace Postgres.Marula.Tests.Infrastructure
 		private static IEnumerable<ParseTestCase> ParseTestCases() =>
 			new ParseTestCase[]
 			{
-				new("0B", Memory.Zero),
-				new("1B", Memory.Byte),
-				new("1kB", Memory.Kilobyte),
-				new("1MB", Memory.Megabyte),
-				new("1GB", Memory.Gigabyte),
-				new("1TB", Memory.Terabyte),
+				new("0B",    Memory.Zero),
+				new("1B",    Memory.Byte),
+				new("1kB",   Memory.Kilobyte),
+				new("1MB",   Memory.Megabyte),
+				new("1GB",   Memory.Gigabyte),
+				new("1TB",   Memory.Terabyte),
 				new("32 GB", 32 * Memory.Gigabyte)
 			};
 
@@ -61,7 +61,17 @@ namespace Postgres.Marula.Tests.Infrastructure
 		private static IEnumerable<OperatorTestCase> OperatorTestCases()
 			=> new OperatorTestCase[]
 			{
-				new(() => 0.25 * Memory.Gigabyte, Memory.Parse("256MB"))
+				new(() => 25 * Memory.Gigabyte,    Memory.Parse("25GB")),
+				new(() => Memory.Terabyte * 32,    Memory.Parse("32TB")),
+				new(() => Memory.Megabyte / 64,    Memory.Parse("16kB")),
+
+				new(() => 0.25 * Memory.Kilobyte,  Memory.Parse("256B")),
+				new(() => Memory.Megabyte * 0.125, Memory.Parse("128kB")),
+				new(() => Memory.Gigabyte / 0.125, Memory.Parse("8GB")),
+
+				new(() => 8M * Memory.Byte,        Memory.Parse("8B")),
+				new(() => Memory.Megabyte * 48M,   Memory.Parse("48MB")),
+				new(() => Memory.Gigabyte / 0.01M, Memory.Parse("100GB"))
 			};
 
 		/// <summary>

--- a/src/Postgres.Marula.Tests/Infrastructure/MemoryTests.cs
+++ b/src/Postgres.Marula.Tests/Infrastructure/MemoryTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Postgres.Marula.Infrastructure.TypeDecorators;
+
+namespace Postgres.Marula.Tests.Infrastructure
+{
+	/// <summary>
+	/// Tests of <see cref="Memory"/> type.
+	/// </summary>
+	[TestFixture]
+	internal class MemoryTests
+	{
+		/// <summary>
+		/// Test of <see cref="Memory.Parse"/> method.
+		/// </summary>
+		[Test]
+		[TestCaseSource(nameof(ParseTestCases))]
+		public void ParseTest(ParseTestCase testCase)
+		{
+			var (input, expected) = testCase;
+			var result = Memory.Parse(input);
+			Assert.AreEqual(expected, result);
+		}
+
+		/// <summary>
+		/// Test cases for <see cref="ParseTest"/>.
+		/// </summary>
+		private static IEnumerable<ParseTestCase> ParseTestCases() =>
+			new ParseTestCase[]
+			{
+				new("0B", Memory.Zero),
+				new("1B", Memory.Byte),
+				new("1kB", Memory.Kilobyte),
+				new("1MB", Memory.Megabyte),
+				new("1GB", Memory.Gigabyte),
+				new("1TB", Memory.Terabyte),
+				new("32 GB", 32 * Memory.Gigabyte)
+			};
+
+		/// <summary>
+		/// Test case for <see cref="ParseTest"/>.
+		/// </summary>
+		public sealed record ParseTestCase(NonEmptyString Input, Memory Expected);
+
+		/// <summary>
+		/// Test of operators defined in <see cref="Memory"/> type. 
+		/// </summary>
+		[Test]
+		[TestCaseSource(nameof(OperatorTestCases))]
+		public void OperatorTest(OperatorTestCase testCase)
+		{
+			var (operation, expected) = testCase;
+			var result = operation();
+			Assert.AreEqual(expected, result);
+		}
+
+		/// <summary>
+		/// Test cases for <see cref="OperatorTest"/>.
+		/// </summary>
+		private static IEnumerable<OperatorTestCase> OperatorTestCases()
+			=> new OperatorTestCase[]
+			{
+				new(() => 0.25 * Memory.Gigabyte, 256 * Memory.Megabyte)
+			};
+
+		/// <summary>
+		/// Test case for <see cref="OperatorTest"/>.
+		/// </summary>
+		public sealed record OperatorTestCase(Func<Memory> Operation, Memory Expected);
+	}
+}


### PR DESCRIPTION
fixing of bugs found during manual testing
| #    |                       bug description                        |                           solution                           |
| ---- | :----------------------------------------------------------: | :----------------------------------------------------------: |
| 0    | agent access error always led to whole calculations iteration failure | introduced `RemoteAgentAccessException` exception type which is being thrown by `RemoteHardwareInfo` and being handled in `ParameterBase.CalculateInternalAsync` |
| 1    | `Memory` type was always deserialized to `default` in `RemoteHardwareInfo.PerformRequestAsync<T>` | added custom read-only json converter `MemoryConverter`; `RemoteHardwareInfo` covered with unit tests |
| 2    | multiplication operators defined in `Memory` type rounded fractional numbers to zero | fixed rounding in `Memory` operators; `Memory` type covered with unit tests |
| 3    | absence of bloat fraction history always led to whole  calculations iteration failure | throw `ParameterValueCalculationException` in `BloatAlalysis.ExecuteAsync` |
| 4    | **autovacuum_vacuum_threshold** could be calculated to zero when tables in database have small size | added lower bound of 50 tuples for **autovacuum_vacuum_threshold** |
| 5    | `ISystemStorage.SaveParameterValuesAsync` always executed after `IPgSettings.FlushAsync`, so values history table wasn't filling | changed order of middleware components in calculation pipeline |
| 6    | `DefaultDbConnectionFactory.PrepareConnectionAsync` could fail due to race condition | introduced `Lock` type which wraps `SemaphoreSlim` and provides disposing. used `Lock.AcquireAsync` with 1 minute timeout in `PrepareConnectionAsync` |
| 7    | logging warn message in `ValueCalculationsMiddleware` led to whole calculations iteration failure because of `NullValue.Link` property access | now `NullValue.Link` doesn't throw `InvalidOperationException`  and returns link to parameter value of which wasn't calculated for some reason |
| 8    | unit tests session could failed after agent process killing in `SetUpFixture.OneTimeTearDown` | replaced `RemoteHardwareInfo` with `FakeHardwareInfo` in `CalculationsTestFixtureBase` and moved agent process management to separete test class - `RemoteHardwareInfoTests` |