### PR TITLE
feature/asynchronous behavour

### DIFF
--- a/src/Postgres.Marula.Calculations/Parameters/Autovacuum/AutovacuumVacuumCostLimit.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/Autovacuum/AutovacuumVacuumCostLimit.cs
@@ -7,7 +7,7 @@ using Postgres.Marula.Calculations.ParametersManagement;
 // ReSharper disable UnusedType.Global
 // ReSharper disable BuiltInTypeReferenceStyle
 using CostLimit = System.UInt32;
-using WorkersCount = System.UInt32;
+using CoresCount = System.UInt32;
 
 namespace Postgres.Marula.Calculations.Parameters.Autovacuum
 {
@@ -35,7 +35,7 @@ namespace Postgres.Marula.Calculations.Parameters.Autovacuum
 			// todo: perform calculations based on BloatCoefficients.
 			await bloatAnalysis.ExecuteAsync();
 
-			var autovacuumMaxWorkers = await pgSettings.ReadAsync<AutovacuumMaxWorkers, WorkersCount>();
+			var autovacuumMaxWorkers = await pgSettings.ReadAsync<AutovacuumMaxWorkers, CoresCount>();
 			return 500 * autovacuumMaxWorkers;
 		}
 	}

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/AsynchronousBehaviour/MaxParallelMaintenanceWorkers.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/AsynchronousBehaviour/MaxParallelMaintenanceWorkers.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Postgres.Marula.Calculations.Parameters.Base;
+using Postgres.Marula.HwInfo;
+
+// ReSharper disable UnusedType.Global
+// ReSharper disable BuiltInTypeReferenceStyle
+using CoresCount = System.UInt32;
+
+namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.AsynchronousBehaviour
+{
+	/// <summary>
+	/// [max_parallel_maintenance_workers]
+	/// Sets the maximum number of parallel processes per maintenance operation.
+	/// </summary>
+	internal class MaxParallelMaintenanceWorkers : IntegerParameterBase
+	{
+		private readonly IHardwareInfo hardwareInfo;
+
+		public MaxParallelMaintenanceWorkers(
+			IHardwareInfo hardwareInfo,
+			ILogger<IntegerParameterBase> logger) : base(logger)
+			=> this.hardwareInfo = hardwareInfo;
+
+		/// <inheritdoc />
+		protected override async ValueTask<uint> CalculateValueAsync()
+		{
+			var cpuCoresCount = await hardwareInfo.CpuCoresCount();
+			return (CoresCount) Math.Min(4, 0.5 * cpuCoresCount);
+		}
+	}
+}

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/AsynchronousBehaviour/MaxParallelWorkers.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/AsynchronousBehaviour/MaxParallelWorkers.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Postgres.Marula.Calculations.Parameters.Base;
+using Postgres.Marula.HwInfo;
+
+// ReSharper disable UnusedType.Global
+
+namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.AsynchronousBehaviour
+{
+	/// <summary>
+	/// [max_parallel_workers]
+	/// Sets the maximum number of parallel workers that can be active at one time.
+	/// </summary>
+	internal class MaxParallelWorkers : IntegerParameterBase
+	{
+		private readonly IHardwareInfo hardwareInfo;
+
+		public MaxParallelWorkers(
+			IHardwareInfo hardwareInfo,
+			ILogger<IntegerParameterBase> logger) : base(logger)
+			=> this.hardwareInfo = hardwareInfo;
+
+		/// <inheritdoc />
+		protected override async ValueTask<uint> CalculateValueAsync() => await hardwareInfo.CpuCoresCount();
+	}
+}

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/AsynchronousBehaviour/MaxParallelWorkersPerGather.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/AsynchronousBehaviour/MaxParallelWorkersPerGather.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Postgres.Marula.Calculations.Parameters.Base;
@@ -7,26 +8,26 @@ using Postgres.Marula.HwInfo;
 // ReSharper disable BuiltInTypeReferenceStyle
 using CoresCount = System.UInt32;
 
-namespace Postgres.Marula.Calculations.Parameters.Autovacuum
+namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.AsynchronousBehaviour
 {
 	/// <summary>
-	/// [autovacuum_max_workers]
-	/// Specifies the maximum number of autovacuum
-	/// processes (other than the autovacuum launcher) that may be running at any one time.
+	/// [max_parallel_workers_per_gather]
+	/// Sets the maximum number of parallel processes per executor node.
 	/// </summary>
-	internal class AutovacuumMaxWorkers : IntegerParameterBase
+	internal class MaxParallelWorkersPerGather : IntegerParameterBase
 	{
 		private readonly IHardwareInfo hardwareInfo;
 
-		public AutovacuumMaxWorkers(
+		public MaxParallelWorkersPerGather(
 			IHardwareInfo hardwareInfo,
 			ILogger<IntegerParameterBase> logger) : base(logger)
 			=> this.hardwareInfo = hardwareInfo;
 
-		protected override async ValueTask<CoresCount> CalculateValueAsync()
+		/// <inheritdoc />
+		protected override async ValueTask<uint> CalculateValueAsync()
 		{
 			var cpuCoresCount = await hardwareInfo.CpuCoresCount();
-			return (CoresCount) (0.5 * cpuCoresCount);
+			return (CoresCount) Math.Min(4, 0.5 * cpuCoresCount);
 		}
 	}
 }

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/AsynchronousBehaviour/MaxWorkerProcesses.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/AsynchronousBehaviour/MaxWorkerProcesses.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Postgres.Marula.Calculations.Parameters.Base;
+using Postgres.Marula.HwInfo;
+
+// ReSharper disable UnusedType.Global
+
+namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.AsynchronousBehaviour
+{
+	/// <summary>
+	/// [max_worker_processes]
+	/// Maximum number of concurrent worker processes.
+	/// </summary>
+	internal class MaxWorkerProcesses : IntegerParameterBase
+	{
+		private readonly IHardwareInfo hardwareInfo;
+
+		public MaxWorkerProcesses(
+			IHardwareInfo hardwareInfo,
+			ILogger<IntegerParameterBase> logger) : base(logger)
+			=> this.hardwareInfo = hardwareInfo;
+
+		/// <inheritdoc />
+		protected override async ValueTask<uint> CalculateValueAsync() => await hardwareInfo.CpuCoresCount();
+	}
+}

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/AutovacuumWorkMem.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/AutovacuumWorkMem.cs
@@ -9,6 +9,7 @@ using Postgres.Marula.HwInfo;
 // ReSharper disable UnusedType.Global
 // ReSharper disable BuiltInTypeReferenceStyle
 using WorkersCount = System.UInt32;
+using Mem = Postgres.Marula.Infrastructure.TypeDecorators.Memory;
 
 namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 {
@@ -38,7 +39,7 @@ namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 				.DependsOn<AutovacuumMaxWorkers>();
 
 		/// <inheritdoc />
-		protected override async ValueTask<Infrastructure.TypeDecorators.Memory> CalculateValueAsync()
+		protected override async ValueTask<Mem> CalculateValueAsync()
 		{
 			var totalRamSize = await hardwareInfo.TotalRam();
 			var autovacuumMaxWorkers = await pgSettings.ReadAsync<AutovacuumMaxWorkers, WorkersCount>();

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/AutovacuumWorkMem.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/AutovacuumWorkMem.cs
@@ -5,13 +5,12 @@ using Postgres.Marula.Calculations.Parameters.Base;
 using Postgres.Marula.Calculations.Parameters.Base.Dependencies;
 using Postgres.Marula.Calculations.ParametersManagement;
 using Postgres.Marula.HwInfo;
-using Postgres.Marula.Infrastructure.TypeDecorators;
 
 // ReSharper disable UnusedType.Global
 // ReSharper disable BuiltInTypeReferenceStyle
 using WorkersCount = System.UInt32;
 
-namespace Postgres.Marula.Calculations.Parameters.MemoryUsage
+namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 {
 	/// <summary>
 	/// [autovacuum_work_mem]
@@ -39,7 +38,7 @@ namespace Postgres.Marula.Calculations.Parameters.MemoryUsage
 				.DependsOn<AutovacuumMaxWorkers>();
 
 		/// <inheritdoc />
-		protected override async ValueTask<Memory> CalculateValueAsync()
+		protected override async ValueTask<Infrastructure.TypeDecorators.Memory> CalculateValueAsync()
 		{
 			var totalRamSize = await hardwareInfo.TotalRam();
 			var autovacuumMaxWorkers = await pgSettings.ReadAsync<AutovacuumMaxWorkers, WorkersCount>();

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/AutovacuumWorkMem.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/AutovacuumWorkMem.cs
@@ -8,7 +8,7 @@ using Postgres.Marula.HwInfo;
 
 // ReSharper disable UnusedType.Global
 // ReSharper disable BuiltInTypeReferenceStyle
-using WorkersCount = System.UInt32;
+using CoresCount = System.UInt32;
 using Mem = Postgres.Marula.Infrastructure.TypeDecorators.Memory;
 
 namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
@@ -42,7 +42,7 @@ namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 		protected override async ValueTask<Mem> CalculateValueAsync()
 		{
 			var totalRamSize = await hardwareInfo.TotalRam();
-			var autovacuumMaxWorkers = await pgSettings.ReadAsync<AutovacuumMaxWorkers, WorkersCount>();
+			var autovacuumMaxWorkers = await pgSettings.ReadAsync<AutovacuumMaxWorkers, CoresCount>();
 			return 0.1 * totalRamSize / autovacuumMaxWorkers;
 		}
 	}

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/MaintenanceWorkMem.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/MaintenanceWorkMem.cs
@@ -2,11 +2,10 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Postgres.Marula.Calculations.Parameters.Base;
 using Postgres.Marula.HwInfo;
-using Postgres.Marula.Infrastructure.TypeDecorators;
 
 // ReSharper disable UnusedType.Global
 
-namespace Postgres.Marula.Calculations.Parameters.MemoryUsage
+namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 {
 	/// <summary>
 	/// [maintenance_work_mem]
@@ -23,7 +22,7 @@ namespace Postgres.Marula.Calculations.Parameters.MemoryUsage
 			=> this.hardwareInfo = hardwareInfo;
 
 		/// <inheritdoc />
-		protected override async ValueTask<Memory> CalculateValueAsync()
+		protected override async ValueTask<Infrastructure.TypeDecorators.Memory> CalculateValueAsync()
 		{
 			var totalRamSize = await hardwareInfo.TotalRam();
 			return 0.05 * totalRamSize;

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/MaintenanceWorkMem.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/MaintenanceWorkMem.cs
@@ -4,6 +4,7 @@ using Postgres.Marula.Calculations.Parameters.Base;
 using Postgres.Marula.HwInfo;
 
 // ReSharper disable UnusedType.Global
+using Mem = Postgres.Marula.Infrastructure.TypeDecorators.Memory;
 
 namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 {
@@ -22,7 +23,7 @@ namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 			=> this.hardwareInfo = hardwareInfo;
 
 		/// <inheritdoc />
-		protected override async ValueTask<Infrastructure.TypeDecorators.Memory> CalculateValueAsync()
+		protected override async ValueTask<Mem> CalculateValueAsync()
 		{
 			var totalRamSize = await hardwareInfo.TotalRam();
 			return 0.05 * totalRamSize;

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/SharedBuffers.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/SharedBuffers.cs
@@ -4,6 +4,7 @@ using Postgres.Marula.Calculations.Parameters.Base;
 using Postgres.Marula.HwInfo;
 
 // ReSharper disable UnusedType.Global
+using Mem = Postgres.Marula.Infrastructure.TypeDecorators.Memory;
 
 namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 {
@@ -21,7 +22,7 @@ namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 			=> this.hardwareInfo = hardwareInfo;
 
 		/// <inheritdoc />
-		protected override async ValueTask<Infrastructure.TypeDecorators.Memory> CalculateValueAsync()
+		protected override async ValueTask<Mem> CalculateValueAsync()
 		{
 			var totalRamSize = await hardwareInfo.TotalRam();
 			return 0.25 * totalRamSize;

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/SharedBuffers.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/SharedBuffers.cs
@@ -2,11 +2,10 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Postgres.Marula.Calculations.Parameters.Base;
 using Postgres.Marula.HwInfo;
-using Postgres.Marula.Infrastructure.TypeDecorators;
 
 // ReSharper disable UnusedType.Global
 
-namespace Postgres.Marula.Calculations.Parameters.MemoryUsage
+namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 {
 	/// <summary>
 	/// [shared_buffers]
@@ -22,7 +21,7 @@ namespace Postgres.Marula.Calculations.Parameters.MemoryUsage
 			=> this.hardwareInfo = hardwareInfo;
 
 		/// <inheritdoc />
-		protected override async ValueTask<Memory> CalculateValueAsync()
+		protected override async ValueTask<Infrastructure.TypeDecorators.Memory> CalculateValueAsync()
 		{
 			var totalRamSize = await hardwareInfo.TotalRam();
 			return 0.25 * totalRamSize;

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/WorkMem.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/WorkMem.cs
@@ -5,6 +5,7 @@ using Postgres.Marula.Calculations.ParametersManagement;
 using Postgres.Marula.HwInfo;
 
 // ReSharper disable UnusedType.Global
+using Mem = Postgres.Marula.Infrastructure.TypeDecorators.Memory;
 
 namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 {
@@ -28,7 +29,7 @@ namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 		}
 
 		/// <inheritdoc />
-		protected override async ValueTask<Infrastructure.TypeDecorators.Memory> CalculateValueAsync()
+		protected override async ValueTask<Mem> CalculateValueAsync()
 		{
 			var totalRamSize = await hardwareInfo.TotalRam();
 			var maxConnections = await pgSettings.ReadAsync<uint>("max_connections");

--- a/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/WorkMem.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/ResourceUsage/Memory/WorkMem.cs
@@ -3,11 +3,10 @@ using Microsoft.Extensions.Logging;
 using Postgres.Marula.Calculations.Parameters.Base;
 using Postgres.Marula.Calculations.ParametersManagement;
 using Postgres.Marula.HwInfo;
-using Postgres.Marula.Infrastructure.TypeDecorators;
 
 // ReSharper disable UnusedType.Global
 
-namespace Postgres.Marula.Calculations.Parameters.MemoryUsage
+namespace Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory
 {
 	/// <summary>
 	/// [work_mem]
@@ -29,7 +28,7 @@ namespace Postgres.Marula.Calculations.Parameters.MemoryUsage
 		}
 
 		/// <inheritdoc />
-		protected override async ValueTask<Memory> CalculateValueAsync()
+		protected override async ValueTask<Infrastructure.TypeDecorators.Memory> CalculateValueAsync()
 		{
 			var totalRamSize = await hardwareInfo.TotalRam();
 			var maxConnections = await pgSettings.ReadAsync<uint>("max_connections");

--- a/src/Postgres.Marula.Calculations/Parameters/Wal/WalBuffers.cs
+++ b/src/Postgres.Marula.Calculations/Parameters/Wal/WalBuffers.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Postgres.Marula.Calculations.Parameters.Base;
+using Postgres.Marula.Calculations.Parameters.Base.Dependencies;
+using Postgres.Marula.Calculations.Parameters.ResourceUsage.Memory;
+using Postgres.Marula.Calculations.ParametersManagement;
+using Postgres.Marula.Infrastructure.Extensions;
+using Postgres.Marula.Infrastructure.TypeDecorators;
+
+// ReSharper disable UnusedType.Global
+
+namespace Postgres.Marula.Calculations.Parameters.Wal
+{
+	/// <summary>
+	/// [wal_buffers]
+	/// Sets the number of disk-page buffers in shared memory for WAL.
+	/// </summary>
+	internal class WalBuffers : MemoryParameterBase
+	{
+		private readonly IPgSettings pgSettings;
+
+		public WalBuffers(
+			IPgSettings pgSettings,
+			ILogger<MemoryParameterBase> logger) : base(logger)
+			=> this.pgSettings = pgSettings;
+
+		/// <inheritdoc />
+		public override IParameterDependencies Dependencies()
+			=> ParameterDependencies
+				.Empty
+				.DependsOn<SharedBuffers>();
+
+		/// <inheritdoc />
+		protected override async ValueTask<Memory> CalculateValueAsync()
+		{
+			var sharedBuffers = await pgSettings.ReadAsync<SharedBuffers, Memory>();
+			var fractionOfBuffers = sharedBuffers / 32;
+			return fractionOfBuffers.Limit(64 * Memory.Kilobyte, 32 * Memory.Megabyte);
+		}
+	}
+}

--- a/src/Postgres.Marula.Infrastructure/Extensions/GenericExtensions.cs
+++ b/src/Postgres.Marula.Infrastructure/Extensions/GenericExtensions.cs
@@ -34,10 +34,21 @@ namespace Postgres.Marula.Infrastructure.Extensions
 		}
 
 		/// <summary>
-		/// Check if value <paramref name="value"/> belongs to range [<paramref name="leftBound"/> .. <paramref name="rightBound"/>]. 
+		/// Check if value <paramref name="value"/> belongs to range [<paramref name="leftBound"/> .. <paramref name="rightBound"/>].
 		/// </summary>
 		public static bool InRangeBetween<T>(this T value, T leftBound, T rightBound)
 			where T : IComparable<T>
 			=> value.CompareTo(leftBound) >= 0 && value.CompareTo(rightBound) <= 0;
+
+		/// <summary>
+		/// Limit <paramref name="value"/> with range [<paramref name="leftBound"/> .. <paramref name="rightBound"/>].
+		/// </summary>
+		public static T Limit<T>(this T value, T leftBound, T rightBound)
+			where T : IComparable<T>
+		{
+			if (value.CompareTo(leftBound) < 0) return leftBound;
+			if (value.CompareTo(rightBound) > 0) return rightBound;
+			return value;
+		}
 	}
 }

--- a/src/Postgres.Marula.Infrastructure/TypeDecorators/Memory.cs
+++ b/src/Postgres.Marula.Infrastructure/TypeDecorators/Memory.cs
@@ -7,7 +7,7 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 	/// <summary>
 	/// Memory volume.
 	/// </summary>
-	public readonly struct Memory : IEquatable<Memory>
+	public readonly struct Memory : IEquatable<Memory>, IComparable<Memory>, IComparable
 	{
 		public Memory(ulong totalBytes) => TotalBytes = totalBytes;
 
@@ -58,15 +58,15 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 		/// <inheritdoc />
 		public override int GetHashCode() => TotalBytes.GetHashCode();
 
-		/// <summary>
-		/// Equality operator. 
-		/// </summary>
-		public static bool operator ==(Memory left, Memory right) => left.Equals(right);
+		/// <inheritdoc />
+		public int CompareTo(Memory other) => TotalBytes.CompareTo(other.TotalBytes);
 
-		/// <summary>
-		/// Inequality operator. 
-		/// </summary>
-		public static bool operator !=(Memory left, Memory right) => !(left == right);
+		/// <inheritdoc />
+		int IComparable.CompareTo(object? obj)
+		{
+			if (ReferenceEquals(null, obj)) return 1;
+			return obj is Memory other ? CompareTo(other) : throw new ArgumentException($"Object must be of type {nameof(Memory)}");
+		}
 
 		#endregion
 
@@ -136,6 +136,30 @@ namespace Postgres.Marula.Infrastructure.TypeDecorators
 		}
 
 		#region Operators
+
+		/// <summary>
+		/// Equality operator. 
+		/// </summary>
+		public static bool operator ==(Memory left, Memory right) => left.Equals(right);
+
+		/// <summary>
+		/// Inequality operator. 
+		/// </summary>
+		public static bool operator !=(Memory left, Memory right) => !(left == right);
+
+		/// <summary>
+		/// Comparison operator.
+		/// </summary>
+		public static bool operator <(Memory left, Memory right) => left.CompareTo(right) < 0;
+
+		/// <inheritdoc cref="op_LessThan"/>
+		public static bool operator >(Memory left, Memory right) => left.CompareTo(right) > 0;
+
+		/// <inheritdoc cref="op_LessThan"/>
+		public static bool operator <=(Memory left, Memory right) => left.CompareTo(right) <= 0;
+
+		/// <inheritdoc cref="op_LessThan"/>
+		public static bool operator >=(Memory left, Memory right) => left.CompareTo(right) >= 0;
 
 		/// <summary>
 		/// Multiplication operator.

--- a/src/Postgres.Marula.Tests/Calculations/FakeServices/FakeHardwareInfo.cs
+++ b/src/Postgres.Marula.Tests/Calculations/FakeServices/FakeHardwareInfo.cs
@@ -11,9 +11,9 @@ namespace Postgres.Marula.Tests.Calculations.FakeServices
 	internal class FakeHardwareInfo : IHardwareInfo
 	{
 		/// <inheritdoc />
-		Task<Memory> IHardwareInfo.TotalRam() => Task.FromResult(16 * Memory.Gigabyte);
+		Task<Memory> IHardwareInfo.TotalRam() => Task.FromResult(32 * Memory.Gigabyte);
 
 		/// <inheritdoc />
-		Task<CoresCount> IHardwareInfo.CpuCoresCount() => Task.FromResult((CoresCount) 8);
+		Task<CoresCount> IHardwareInfo.CpuCoresCount() => Task.FromResult((CoresCount) 16);
 	}
 }


### PR DESCRIPTION
tuning of async-related parameters
closes #66
+ wal_buffers calculation: `min(max(shared_buffers / 32, 64kB), 32MB)`